### PR TITLE
Filename of generated p12 contains app_identifier

### DIFF
--- a/lib/pem/cert_manager.rb
+++ b/lib/pem/cert_manager.rb
@@ -22,7 +22,7 @@ module PEM
 
       # Generate p12 file as well
       if PEM.config[:generate_p12]
-        output = "#{certificate_type}.p12"
+        output = "#{certificate_type}_#{PEM.config[:app_identifier]}.p12"
         File.write(output, p12_certificate.to_der)
         puts output.green
       end


### PR DESCRIPTION
Having PEM create a `production.p12` smells like trouble, since running PEM for another app identifier will probably replace the existing one.

My change makes the .p12 use the same name as the .pem.

I didn't test this :stuck_out_tongue: 
