### PR TITLE
Fixed default pem file name

### DIFF
--- a/lib/pem/options.rb
+++ b/lib/pem/options.rb
@@ -51,7 +51,7 @@ module PEM
                                      env_name: "PEM_FILE_NAME",
                                      description: "The file name of the generated .pem file",
                                      optional: true,
-                                     default_value: '')
+                                     default_value: nil)
       ]
     end
   end


### PR DESCRIPTION
When the user did not specify a file name, it was created without name, just .pem
