### PR TITLE
add output_path option

### DIFF
--- a/lib/pem/manager.rb
+++ b/lib/pem/manager.rb
@@ -9,7 +9,7 @@ module PEM
       Spaceship.login(password_manager.username, password_manager.password)
       Spaceship.client.select_team
 
-      existing_certificate = certificate.all.detect do |c| 
+      existing_certificate = certificate.all.detect do |c|
         c.name == PEM.config[:app_identifier]
       end
 
@@ -50,25 +50,22 @@ module PEM
       filename_base = File.basename(filename_base, ".pem") # strip off the .pem if it was provided.
 
       if PEM.config[:save_private_key]
-        file = File.new("#{filename_base}.pkey",'w')
-        file.write(pkey.to_pem)
-        file.close
-        Helper.log.info "Private key: ".green + Pathname.new(file).realpath.to_s
+        private_key_path = File.join(PEM.config[:output_path], "#{filename_base}.pkey")
+        File.write(private_key_path, pkey.to_pem)
+        Helper.log.info "Private key: ".green + Pathname.new(private_key_path).realpath.to_s
       end
 
       if PEM.config[:generate_p12]
+        p12_cert_path = File.join(PEM.config[:output_path], "#{filename_base}.p12")
         p12 = OpenSSL::PKCS12.create(PEM.config[:p12_password], certificate_type, pkey, x509_certificate)
-        file = File.new("#{filename_base}.p12", 'wb')
-        file.write(p12.to_der)
-        file.close
-        Helper.log.info "p12 certificate: ".green + Pathname.new(file).realpath.to_s
+        File.write(p12_cert_path, p12.to_der)
+        Helper.log.info "p12 certificate: ".green + Pathname.new(p12_cert_path).realpath.to_s
       end
 
-      file = File.new("#{filename_base}.pem", 'w')
-      file.write(x509_certificate.to_pem + pkey.to_pem)
-      file.close
-      Helper.log.info "PEM: ".green + Pathname.new(file).realpath.to_s
-      return file
+      x509_cert_path = File.join(PEM.config[:output_path], "#{filename_base}.pem")
+      File.write(x509_cert_path, x509_certificate.to_pem + pkey.to_pem)
+      Helper.log.info "PEM: ".green + Pathname.new(x509_cert_path).realpath.to_s
+      return x509_cert_path
     end
 
     def self.certificate

--- a/lib/pem/options.rb
+++ b/lib/pem/options.rb
@@ -12,12 +12,12 @@ module PEM
         FastlaneCore::ConfigItem.new(key: :generate_p12,
                                      env_name: "PEM_GENERATE_P12_FILE",
                                      description: "Generate a p12 file additionally to a PEM file",
-                                     is_string: false, 
+                                     is_string: false,
                                      default_value: true),
         FastlaneCore::ConfigItem.new(key: :save_private_key,
                                      short_option: "-s",
                                      env_name: "PEM_SAVE_PRIVATEKEY",
-                                     description: "Set to save the private RSA key in the current directory",
+                                     description: "Set to save the private RSA key",
                                      is_string: false,
                                      default_value: true),
         FastlaneCore::ConfigItem.new(key: :force,
@@ -55,7 +55,12 @@ module PEM
                                      short_option: "-o",
                                      env_name: "PEM_FILE_NAME",
                                      description: "The file name of the generated .pem file",
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :output_path,
+                                     # short_option: "-o",
+                                     env_name: "PEM_OUTPUT_PATH",
+                                     description: "The path to a directory in which all certificates and private keys should be stored",
+                                     default_value: ".")
       ]
     end
   end

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -7,6 +7,10 @@ describe PEM do
       stub_spaceship
     end
 
+    before :all do
+      FileUtils.mkdir("tmp")
+    end
+
     it "Successful run" do
       options = { app_identifier: "com.krausefx.app", generate_p12: false }
       PEM.config = FastlaneCore::Configuration.create(PEM::Options.available_options, options)
@@ -16,7 +20,18 @@ describe PEM do
       expect(File.exist? "production_com.krausefx.app.pkey").to eq(true)
     end
 
-    after do
+    it "Successful run with output_path" do
+      options = { app_identifier: "com.krausefx.app", generate_p12: false, output_path: "tmp/" }
+      PEM.config = FastlaneCore::Configuration.create(PEM::Options.available_options, options)
+      PEM::Manager.start
+
+      expect(File.exist? "tmp/production_com.krausefx.app.pem").to eq(true)
+      expect(File.exist? "tmp/production_com.krausefx.app.pkey").to eq(true)
+      expect(File.exist? "tmp/production_com.krausefx.app.p12").to eq(false)
+    end
+
+    after :all do
+      FileUtils.rm_r("tmp")
       File.delete("production_com.krausefx.app.pem")
       File.delete("production_com.krausefx.app.pkey")
     end


### PR DESCRIPTION
just like cert & sigh, although could not use the `-o` short option because that is already in use for the pem filename
